### PR TITLE
Update version to 1.0.8

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.kodimansmacplayer" version="1.0.2" name="Kodimans MAC Player" provider-name="Ungatonga">
+<addon id="plugin.video.kodimansmacplayer" version="1.0.8" name="Kodimans MAC Player" provider-name="Ungatonga">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
     </requires>


### PR DESCRIPTION
## Summary
- bump addon version to 1.0.8

## Testing
- `python -m py_compile default.py resources/lib/stalker.py`
- `pip install flake8` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68524ae66bc88331a52ddeeddd9939f2