### PR TITLE
Bump version and update provider name

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.kodimansmacplayer" version="1.0.8" name="Kodimans MAC Player" provider-name="Kodiman_Himself">
+<addon id="plugin.video.kodimansmacplayer" version="1.0.9" name="Kodimans MAC Player" provider-name="Kodiman">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
     </requires>


### PR DESCRIPTION
## Summary
- bump addon version to 1.0.9
- change provider name to Kodiman

## Testing
- `python3 -m py_compile default.py resources/lib/stalker.py`

------
https://chatgpt.com/codex/tasks/task_e_687c11b4c73c8331816914d5a1757d1e