### PR TITLE
Fix channel retrieval and bump version

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.kodimansmacplayer" version="1.0.9" name="Kodimans MAC Player" provider-name="Kodiman">
+<addon id="plugin.video.kodimansmacplayer" version="1.0.10" name="Kodimans MAC Player" provider-name="Kodiman">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
     </requires>

--- a/resources/lib/stalker.py
+++ b/resources/lib/stalker.py
@@ -7,6 +7,7 @@ class StalkerClient:
         self.mac = mac
         self.token = None
         self.profile = {}
+        self.channels = []
         self.headers = {
             "User-Agent": "Mozilla/5.0",
             "Referer": self.portal_url + "/c/",
@@ -42,7 +43,10 @@ class StalkerClient:
         self.profile = self.call_api("get_profile")
 
     def get_all_channels(self):
-        return self.call_api("get_all_channels")
+        if not self.channels:
+            data = self.call_api("get_all_channels")
+            self.channels = data.get("data", [])
+        return self.channels
 
     def get_stream_link(self, cmd):
         data = self.call_api("create_link", {"cmd": cmd})


### PR DESCRIPTION
## Summary
- fix StalkerClient channel retrieval and cache the result
- bump addon version to 1.0.10

## Testing
- `python -m py_compile default.py resources/lib/stalker.py`
- `pylint default.py resources/lib/stalker.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6090086c83319de3f9e61cd5e438