### PR TITLE
Add requests module dependency

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -2,6 +2,7 @@
 <addon id="plugin.video.kodimansmacplayer" version="1.0.10" name="Kodimans MAC Player" provider-name="Kodiman">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
+        <import addon="script.module.requests" version="2.20.0"/>
     </requires>
     <extension point="xbmc.python.pluginsource" library="default.py">
         <provides>video</provides>


### PR DESCRIPTION
## Summary
- add `script.module.requests` as a required dependency in `addon.xml`

## Testing
- `python -m py_compile default.py`
- `python -m py_compile resources/lib/stalker.py`
- `pip install requests` *(fails: Could not connect to proxy / No matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba64cb45548331a72a06de44f0b2f9