### PR TITLE
Remove requests dependency

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -2,7 +2,6 @@
 <addon id="plugin.video.kodimansmacplayer" version="1.0.10" name="Kodimans MAC Player" provider-name="Kodiman">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
-        <import addon="script.module.requests" version="2.20.0"/>
     </requires>
     <extension point="xbmc.python.pluginsource" library="default.py">
         <provides>video</provides>

--- a/resources/lib/stalker.py
+++ b/resources/lib/stalker.py
@@ -1,4 +1,8 @@
-import requests
+"""Stalker portal client using only Python's standard library."""
+
+import json
+import urllib.parse
+import urllib.request
 
 
 class StalkerClient:
@@ -11,16 +15,15 @@ class StalkerClient:
         self.headers = {
             "User-Agent": "Mozilla/5.0",
             "Referer": self.portal_url + "/c/",
-            "Cookie": f"mac={self.mac}; stb_lang=en; timezone=Europe/Berlin"
+            "Cookie": f"mac={self.mac}; stb_lang=en; timezone=Europe/Berlin",
         }
-        self.session = requests.Session()
 
     def call_api(self, endpoint, params=None):
         url = f"{self.portal_url}/portal.php"
         base_params = {
             "type": "stb",
             "action": endpoint,
-            "JsHttpRequest": "1-xml"
+            "JsHttpRequest": "1-xml",
         }
         if params:
             base_params.update(params)
@@ -29,10 +32,11 @@ class StalkerClient:
         if self.token:
             headers["Authorization"] = f"Bearer {self.token}"
 
-        response = self.session.get(
-            url, params=base_params, headers=headers, timeout=10
-        )
-        data = response.json()
+        query = urllib.parse.urlencode(base_params)
+        full_url = f"{url}?{query}"
+        request = urllib.request.Request(full_url, headers=headers)
+        with urllib.request.urlopen(request, timeout=10) as response:
+            data = json.load(response)
         return data.get("js", {})
 
     def handshake(self):
@@ -55,3 +59,4 @@ class StalkerClient:
     def initialize(self):
         self.handshake()
         self.get_profile()
+


### PR DESCRIPTION
## Summary
- replace requests-based Stalker client with urllib implementation to avoid missing dependency
- remove script.module.requests from addon requirements

## Testing
- `python -m py_compile default.py resources/lib/stalker.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba689f7cbc8331802113583ce2fdb8