### PR TITLE
Bump addon version to 1.0.12

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.kodimansmacplayer" version="1.0.10" name="Kodimans MAC Player" provider-name="Kodiman">
+<addon id="plugin.video.kodimansmacplayer" version="1.0.12" name="Kodimans MAC Player" provider-name="Kodiman">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
     </requires>


### PR DESCRIPTION
## Summary
- bump addon version to 1.0.12

## Testing
- `python -m py_compile default.py resources/lib/stalker.py`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68ba696b4dd48331809d9d0df3759db8)

## Summary by Sourcery

Bump the Kodimans MAC Player addon manifest version from 1.0.10 to 1.0.12.